### PR TITLE
Change all bintray downloads to HTTPS attempt 2

### DIFF
--- a/plugins/JREkiwi/SageMC.xml
+++ b/plugins/JREkiwi/SageMC.xml
@@ -63,7 +63,7 @@
 
   <Package>
     <PackageType>STV</PackageType>
-    <Location>http://bintray.com/jrekiwi/SageTV/download_file?file_path=SageMC%2Fsagemc-stv-7.0.11.zip</Location>
+    <Location>https://bintray.com/jrekiwi/SageTV/download_file?file_path=SageMC%2Fsagemc-stv-7.0.11.zip</Location>
     <MD5>DCEC3911DBC4503F58E7A3AAB2F93A98</MD5>
   </Package>
 <ReleaseNotes>

--- a/plugins/bmtweb/bmtweb-plugin.xml
+++ b/plugins/bmtweb/bmtweb-plugin.xml
@@ -49,7 +49,7 @@
 
 	<Package>
 		<PackageType>System</PackageType>
-		<Location>http://dl.bintray.com/opensagetv/sagetv-plugins/bmtweb/4.101.0/bmtweb-war-4.101.0.zip
+		<Location>https://dl.bintray.com/opensagetv/sagetv-plugins/bmtweb/4.101.0/bmtweb-war-4.101.0.zip
 		</Location>
 		<MD5>e4e1d5081665f3edfbdce65e03b0ad5c</MD5>
 	</Package>
@@ -57,7 +57,7 @@
 	<!-- context file must be installed after the war file -->
 	<Package>
 		<PackageType>System</PackageType>
-		<Location>http://dl.bintray.com/opensagetv/sagetv-plugins/bmtweb/4.101.0/bmtweb-context-4.101.0.zip
+		<Location>https://dl.bintray.com/opensagetv/sagetv-plugins/bmtweb/4.101.0/bmtweb-context-4.101.0.zip
 		</Location>
 		<MD5>38ac727c6ef38cad0f9a90e4bc8cdc95</MD5>
 	</Package>

--- a/plugins/gemstone/DiamondSTVi.xml
+++ b/plugins/gemstone/DiamondSTVi.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <SageTVPlugin>
 
-  <Name>Gemstone for Default SageTV9 (previously Diamond)</Name> 
-  <Identifier>DiamondSTVi</Identifier> 
-  <Description>Major update of the Diamond STVi.</Description> 
-  <Author>JOrton,jusjoken,Fuzzy,EvilPenguin,bialio,PluckyHD</Author> 
-  <CreationDate>2010.11.01</CreationDate> 
+  <Name>Gemstone for Default SageTV9 (previously Diamond)</Name>
+  <Identifier>DiamondSTVi</Identifier>
+  <Description>Major update of the Diamond STVi.</Description>
+  <Author>JOrton,jusjoken,Fuzzy,EvilPenguin,bialio,PluckyHD</Author>
+  <CreationDate>2010.11.01</CreationDate>
   <ModificationDate>2019.01.20</ModificationDate>
-  <Version>4.0501</Version> 
+  <Version>4.0501</Version>
 
   <Dependency>
    <Core/>
@@ -25,76 +25,75 @@
   </Dependency>
 
   <Dependency>
-   <Plugin>gemstone-api</Plugin> 
-   <MinVersion>1.0501</MinVersion> 
+   <Plugin>gemstone-api</Plugin>
+   <MinVersion>1.0501</MinVersion>
   </Dependency>
 
   <Dependency>
-   <Plugin>gemstone-theme</Plugin> 
-   <MinVersion>1.0407</MinVersion> 
+   <Plugin>gemstone-theme</Plugin>
+   <MinVersion>1.0407</MinVersion>
   </Dependency>
 
   <Dependency>
-   <Plugin>gemstone-icons</Plugin> 
-   <MinVersion>1.013</MinVersion> 
+   <Plugin>gemstone-icons</Plugin>
+   <MinVersion>1.013</MinVersion>
   </Dependency>
 
-  <PluginType>STVI</PluginType> 
+  <PluginType>STVI</PluginType>
 
   <Package>
-   <PackageType>STV</PackageType> 
-   <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/Gemstone1_0501.zip</Location> 
-   <MD5>557f8bc9c8b5bab7e000bd9d90007204</MD5> 
+   <PackageType>STV</PackageType>
+   <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/Gemstone1_0501.zip</Location>
+   <MD5>557f8bc9c8b5bab7e000bd9d90007204</MD5>
   </Package>
 
   <Package>
-    <PackageType>STV</PackageType> 
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneDefaults1_0401.zip</Location> 
-    <MD5>00775be716070c5ecd0e2ed4a2378485</MD5> 
+    <PackageType>STV</PackageType>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneDefaults1_0401.zip</Location> 
+    <MD5>00775be716070c5ecd0e2ed4a2378485</MD5>
   </Package>
 
-  <STVImport>GemstonePlugin.stvi</STVImport> 
+  <STVImport>GemstonePlugin.stvi</STVImport>
 
   <ReleaseNotes>
     Version 1.0501 Removed Weather Underground and fixed Yahoo Weather
-                   Added Dark Sky Weather - this requires a developer key. 
-                    - Sign up at https://darksky.net/dev 
+                   Added Dark Sky Weather - this requires a developer key.
+                    - Sign up at https://darksky.net/dev
                     - Create a file in the root SageTV folder called darksky.properties with only 1 line in it "key=userkey"
                     - no quotes in the line and replace userkey with the one you get when signing up
                     - without a user key Dark Sky provider will not update other than on restart of the server
-    Version 1.0407 Fix for checked and unchecked images 
+    Version 1.0407 Fix for checked and unchecked images
     Version 1.0406 Fix for Android Mini Client image issue
     Version 1.0404 Fix for Windows Client to get weather location from server
     Version 1.0403 Fix for EpisodeSimpleList losing focus after play
     Version 1.0402 Minor change to handle default weather location
     Version 1.0401 Based on SageTV v9.1.7 STV plus various fixes - see forums
-    Version 1.0301 Based on SageTV v9 STV 
-    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code 
-    Version 1.0201 YouTube Fixes, New/updated Task Switcher and started working on icons for menus 
-    Version 1.0194 Minor fixes for reported issues 
-    Version 1.0193 New Dual Flow plus numerous changes/fixes - see forums 
-    Version 1.0182 Numerous changes/fixes - see forums 
-    Version 1.0174 Update to include Sage 7.1.9.10 base (YouTube changes) 
-    Version 1.0173 First Public beta release 
-    Version 1.017 Numerous changes/fixes - see forums 
-    Version 1.0162 Fix for menu items loading before init completed 
-    Version 1.0161 Fix for compatibility issue for other plugins. 
-    Version 1.016 First Full STV version.  Changes to improve memory footprint. 
-    Version 1.015 Numerous changes/fixes - see forums 
-    Version 1.014 Minor changes to support rotated images on the extenders 
-    Version 1.013 Numerous changes/fixes plus new Weather system based on phoenix core 
-    Version 1.012 Inline Flow added 
-    Version 1.011 Metro Menu, TodaysRecordings, Menu Tweak, Stage Reflections, Unselected Flow item transparency option, Weather Icons selection, Banner in Sage Flow 
-    Version 1.010 Google and Weather.com supported now, new Gemstone Theme, Menu transparency options, Weather forecast Widget details 
-    Version 1.009 Fixes for Menu Manager shared Menu File 
-    Version 1.008 Fixes, many menu manager changes, common import/export, 360 fix, Disable for non-compatible plugins, others 
-    Version 1.007 Fixes, xml location change, adm fix, more configurable items for flows 
-    Version 1.006 Fixes, memory improvements plus Updates to many Flows and added Fanart and Center Flows 
-    Version 1.005 Fixes plus Sideways Flow, ADM integrated. 
-    Version 1.004 Fixes plus optional View Cache. 
-    Version 1.003 Play options fix and List/Sage Flow updates. 
-    Version 1.002 Initial test release. 
-  </ReleaseNotes> 
+    Version 1.0301 Based on SageTV v9 STV
+    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code
+    Version 1.0201 YouTube Fixes, New/updated Task Switcher and started working on icons for menus
+    Version 1.0194 Minor fixes for reported issues
+    Version 1.0193 New Dual Flow plus numerous changes/fixes - see forums
+    Version 1.0182 Numerous changes/fixes - see forums
+    Version 1.0174 Update to include Sage 7.1.9.10 base (YouTube changes)
+    Version 1.0173 First Public beta release
+    Version 1.017 Numerous changes/fixes - see forums
+    Version 1.0162 Fix for menu items loading before init completed
+    Version 1.0161 Fix for compatibility issue for other plugins.
+    Version 1.016 First Full STV version.  Changes to improve memory footprint.
+    Version 1.015 Numerous changes/fixes - see forums
+    Version 1.014 Minor changes to support rotated images on the extenders
+    Version 1.013 Numerous changes/fixes plus new Weather system based on phoenix core
+    Version 1.012 Inline Flow added
+    Version 1.011 Metro Menu, TodaysRecordings, Menu Tweak, Stage Reflections, Unselected Flow item transparency option, Weather Icons selection, Banner in Sage Flow
+    Version 1.010 Google and Weather.com supported now, new Gemstone Theme, Menu transparency options, Weather forecast Widget details
+    Version 1.009 Fixes for Menu Manager shared Menu File
+    Version 1.008 Fixes, many menu manager changes, common import/export, 360 fix, Disable for non-compatible plugins, others
+    Version 1.007 Fixes, xml location change, adm fix, more configurable items for flows
+    Version 1.006 Fixes, memory improvements plus Updates to many Flows and added Fanart and Center Flows
+    Version 1.005 Fixes plus Sideways Flow, ADM integrated.
+    Version 1.004 Fixes plus optional View Cache.
+    Version 1.003 Play options fix and List/Sage Flow updates.
+    Version 1.002 Initial test release.
+  </ReleaseNotes>
 
 </SageTVPlugin>
-

--- a/plugins/gemstone/gemstone-api.xml
+++ b/plugins/gemstone/gemstone-api.xml
@@ -22,17 +22,16 @@
   <ReleaseNotes>
     Version 1.0501 Minor changes to remove weather underground and add dark sky
     Version 1.0402 Minor change to handle default weather location
-    Version 1.0401 Misc fixes - see forums 
-    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code 
-  </ReleaseNotes> 
+    Version 1.0401 Misc fixes - see forums
+    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code
+  </ReleaseNotes>
   <PluginType>Standard</PluginType>
-  <ImplementationClass>Gemstone.GemstonePlugin</ImplementationClass> 
+  <ImplementationClass>Gemstone.GemstonePlugin</ImplementationClass>
 
   <Package>
     <PackageType>JAR</PackageType>
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneAPI1_0501.zip</Location>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneAPI1_0501.zip</Location>
     <MD5>ca7d9bf5aa6a283676b55a5ba252da64</MD5>
   </Package>
 
 </SageTVPlugin>
-

--- a/plugins/gemstone/gemstone-theme.xml
+++ b/plugins/gemstone/gemstone-theme.xml
@@ -12,14 +12,14 @@
   <PluginType>Library</PluginType>
 
   <ReleaseNotes>
-    Version 1.0407 Fix for checked and unchecked images 
-    Version 1.0406 JOrton updated the pngs to work with Android Mini Client better 
-    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code 
-  </ReleaseNotes> 
+    Version 1.0407 Fix for checked and unchecked images
+    Version 1.0406 JOrton updated the pngs to work with Android Mini Client better
+    Version 1.0203 NO CHANGES - just moved the packages to BinTray from Google Code
+  </ReleaseNotes>
 
   <Package>
     <PackageType>STV</PackageType>
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneTheme1_0407.zip</Location>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/gemstone/GemstoneTheme1_0407.zip</Location>
     <MD5>269dc2655442d0c6e34299f8a9f1f9fa</MD5>
   </Package>
 </SageTVPlugin>

--- a/plugins/jusjokenCVF/jusjokenCVF.xml
+++ b/plugins/jusjokenCVF/jusjokenCVF.xml
@@ -31,7 +31,7 @@
     - Show Larger Thumbnails (Diamond only)
     - Switch to a Large Preview Thumb (top right) (non-Diamond)
     - Include the Title with the Episode Name
-    * Always Exclude Title from Info List (right side panel) 
+    * Always Exclude Title from Info List (right side panel)
     - Show/Hide thumbnails for video menu items
   </Description>
   <Author>jusjoken</Author>
@@ -45,12 +45,12 @@
   <Dependency>
     <STV>SageTV7</STV>
     <MinVersion>9.0</MinVersion>
-  </Dependency> 
+  </Dependency>
   <PluginType>STVI</PluginType>
   <STVImport>CVF.stvi</STVImport>
   <Package>
     <PackageType>STVI</PackageType>
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/cvf/CVF_1_27.zip</Location>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/cvf/CVF_1_27.zip</Location>
     <MD5>b97f315fb5de4178bd4a2ff5fbb4d75f</MD5>
   </Package>
   <Screenshot>https://github.com/jusjoken/cvf/raw/master/screenshots/CVF_Watched_LargePreview_RemovedThumbs.PNG</Screenshot>

--- a/plugins/phoenix/phoenix3-ui.xml
+++ b/plugins/phoenix/phoenix3-ui.xml
@@ -27,7 +27,7 @@ Phoenix is a STV replacement for SageTV9 providing the following features
 
   <Package>
     <PackageType>STV</PackageType>
-    <Location><![CDATA[http://dl.bintray.com/opensagetv/sagetv-plugins/phoenix3/3.0.200/phoenix-stv-3.0.200.zip]]></Location>
+    <Location><![CDATA[https://dl.bintray.com/opensagetv/sagetv-plugins/phoenix3/3.0.200/phoenix-stv-3.0.200.zip]]></Location>
     <MD5>5e2c24622484c633ec0a86ec12eff5e9</MD5>
   </Package>
 

--- a/plugins/phoenix/plugin-api.xml
+++ b/plugins/phoenix/plugin-api.xml
@@ -79,7 +79,7 @@
 
     <Package>
         <PackageType>JAR</PackageType>
-        <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/phoenix/3.3.0/phoenix-api-3.3.0.zip</Location>
+        <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/phoenix/3.3.0/phoenix-api-3.3.0.zip</Location>
         <MD5>9dcd2fdd1456a3cbbd09fa954ed91cc0</MD5>
     </Package>
 
@@ -93,7 +93,7 @@
 * The API will ignore changes that are the same. ie, setting same provider over and over, or setting the same units or locations, etc, will just be ignored, and not passed to the implementation.
 * The weather configuration can be "locked" (in BMT Weather Configuration). ie, if you have weather set to Yahoo with a location and units, you can "lock" it so that any API request to change this this will be ignored. I did this mainly because of a bug in Gemstore where it keeps changing my weather provider and units
 * SageTV Debugging - Exposed SageTV debugging flags to BMT Web UI (configuration)
- 
+
 # 3.2.1
 * Fixes to allow failed TV lookups to retry (most failures are "Too many connections")
 

--- a/plugins/phoenix/plugin-core.xml
+++ b/plugins/phoenix/plugin-core.xml
@@ -26,7 +26,7 @@
     <PluginType>Standard</PluginType>
     <Package>
         <PackageType>System</PackageType>
-        <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/phoenix/3.3.0/phoenix-core-3.3.0.zip</Location>
+        <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/phoenix/3.3.0/phoenix-core-3.3.0.zip</Location>
         <MD5>5d7d151af3014be5653ab9138fde70ab</MD5>
     </Package>
     <ImplementationClass>sagex.phoenix.plugin.PhoenixPlugin</ImplementationClass>
@@ -40,7 +40,7 @@
 * The API will ignore changes that are the same. ie, setting same provider over and over, or setting the same units or locations, etc, will just be ignored, and not passed to the implementation.
 * The weather configuration can be "locked" (in BMT Weather Configuration). ie, if you have weather set to Yahoo with a location and units, you can "lock" it so that any API request to change this this will be ignored. I did this mainly because of a bug in Gemstore where it keeps changing my weather provider and units
 * SageTV Debugging - Exposed SageTV debugging flags to BMT Web UI (configuration)
- 
+
 # 3.2.1
 * Fixes to allow failed TV lookups to retry (most failures are "Too many connections")
 

--- a/plugins/sagetv/OriginalV2-9.0.1.xml
+++ b/plugins/sagetv/OriginalV2-9.0.1.xml
@@ -16,7 +16,7 @@
 
     <Package>
         <PackageType>STV</PackageType>
-        <Location><![CDATA[http://dl.bintray.com/opensagetv/sagetv/sagetv-themes/9.0/OriginalV2-9.0.1.zip]]></Location>
+        <Location><![CDATA[https://dl.bintray.com/opensagetv/sagetv/sagetv-themes/9.0/OriginalV2-9.0.1.zip]]></Location>
         <MD5>166709c37832906e731bd466d6be5e53</MD5>
     </Package>
 

--- a/plugins/sagetv/SageTV3-9.0.xml
+++ b/plugins/sagetv/SageTV3-9.0.xml
@@ -16,7 +16,7 @@
 
     <Package>
         <PackageType>STV</PackageType>
-        <Location><![CDATA[http://dl.bintray.com/opensagetv/sagetv/sagetv-themes/9.0/SageTV3-9.0.zip]]></Location>
+        <Location><![CDATA[https://dl.bintray.com/opensagetv/sagetv/sagetv-themes/9.0/SageTV3-9.0.zip]]></Location>
         <MD5>0f500cde8bb0ee50354598156e3a2c19</MD5>
     </Package>
 

--- a/plugins/sagex-api/plugin-services.xml
+++ b/plugins/sagex-api/plugin-services.xml
@@ -35,7 +35,7 @@
 
   <Package>
     <PackageType>System</PackageType>
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/sagex-api/9.1.7.0/sagex-api-services-9.1.7.0.zip</Location>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/sagex-api/9.1.7.0/sagex-api-services-9.1.7.0.zip</Location>
     <MD5>532b0de9474793d4f0e4c77a1335ce25</MD5>
   </Package>
 

--- a/plugins/sagex-api/plugin.xml
+++ b/plugins/sagex-api/plugin.xml
@@ -15,7 +15,7 @@
 
   <Package>
     <PackageType>JAR</PackageType>
-    <Location>http://dl.bintray.com/opensagetv/sagetv-plugins/sagex-api/9.1.7.0/sagex-api-9.1.7.0.zip</Location>
+    <Location>https://dl.bintray.com/opensagetv/sagetv-plugins/sagex-api/9.1.7.0/sagex-api-9.1.7.0.zip</Location>
     <MD5>0012e9ca02251b378f12dbcd4a9cd953</MD5>
   </Package>
 


### PR DESCRIPTION
Changed all the plugins that were configured for HTTP to HTTPS as bintray no longer supports HTTP
Last attempt was a bust as I just edited the  SageTVPluginsV9.xml instead of the individual plugin xmls
I've done all the plugins and hope no-one takes offense